### PR TITLE
remove check on nrf52 boards

### DIFF
--- a/dmn_meetstation/include/periph_conf.h
+++ b/dmn_meetstation/include/periph_conf.h
@@ -125,7 +125,6 @@ static const i2c_conf_t i2c_config[] = {
 #define I2C_NUMOF           (sizeof(i2c_config) / sizeof(i2c_config[0]))
 /** @} */
 
-#if defined(BOARD_NRF52DK) || defined(BOARD_NRF52840DK)
 /**
  * @name   PWM configuration
  * @{
@@ -143,8 +142,6 @@ static const pwm_conf_t pwm_config[] = {
 };
 #define PWM_NUMOF           (sizeof(pwm_config) / sizeof(pwm_config[0]))
 /** @} */
-
-#endif
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
Removed check on nrf52 boards since used device is always an nrf52 and it broke the PWM functionality.